### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ "main", "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PokeUwUDevs/Fastbite/security/code-scanning/2](https://github.com/PokeUwUDevs/Fastbite/security/code-scanning/2)

In general, the problem is fixed by explicitly setting `permissions` for the `GITHUB_TOKEN` either at the workflow level (applies to all jobs) or per job. The minimal safe default for a CI job that only checks out code and runs tests is `contents: read`, which limits the token to read-only operations on repository contents.

The best fix here, without changing existing functionality, is to add a `permissions:` block at the root of the workflow, right after the `on:` block. This will apply to the `build-and-test` job and any future jobs that don’t override permissions. Specifically, we should insert:

```yml
permissions:
  contents: read
```

between the `on:` section (lines 3–5) and the `jobs:` section (line 7). No other steps, actions, or configuration need to change. No imports or additional definitions are required because `permissions` is a native GitHub Actions workflow key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
