### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Construir y Publicar Docker
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/PokeUwUDevs/Fastbite/security/code-scanning/1](https://github.com/PokeUwUDevs/Fastbite/security/code-scanning/1)

Generally, to fix this kind of issue you explicitly declare `permissions` either at the workflow root (applies to all jobs) or inside each job (applies only to that job). You then grant only the minimum scopes required for the workflow to function. For this workflow, the steps only need to read the repository to check out the code; all publishing is done to Docker Hub via `secrets`, not via `GITHUB_TOKEN`.

The best fix without changing existing functionality is to add `permissions: contents: read` at the workflow root, just under the `name:` (or just under `on:`) so it applies to all jobs, including `push_to_registry`. This restricts `GITHUB_TOKEN` to read-only access to the repository contents, which is sufficient for `actions/checkout@v4`. No other scopes (like `packages`, `pull-requests`, etc.) are needed for the shown steps. Only `.github/workflows/deploy.yml` needs to be edited, and no additional imports or actions are required.

Concretely, in `.github/workflows/deploy.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` sections (or immediately after `on:` block; root-level placement is sufficient as long as indentation is correct). No other lines need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
